### PR TITLE
Support binding parameters from struct and simplify before_send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
 [workspace]
 resolver = "2"
-members = [
-    "feign-macros",
-    "feign",
-    "test/test-feign",
-    "test/test-server",
-]
+members = ["feign-macros", "feign", "test/test-feign", "test/test-server"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-
 <div align="center">
 
 ![](images/icon.png)
 
 </div>
-
 
 <h1 align="center">
 Feign-RS (Rest client of Rust)
@@ -17,8 +15,8 @@ Feign-RS (Rest client of Rust)
 ```rust
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
-
-use feign::{client, ClientResult};
+use std::collections::HashMap;
+use feign::{client, ClientResult, Args};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct User {
@@ -26,15 +24,29 @@ pub struct User {
     pub name: String,
 }
 
+#[derive(Args)]
+pub struct PutUserArgs {
+    #[arg_path]
+    pub id: i64,
+    #[arg_query]
+    pub q: String,
+    #[arg_json]
+    pub data: User,
+    #[arg_headers]
+    pub headers: HashMap<String, String>,
+}
+
 #[client(host = "http://127.0.0.1:3000", path = "/user")]
 pub trait UserClient {
-    
+
     #[get(path = "/find_by_id/<id>")]
     async fn find_by_id(&self, #[path] id: i64) -> ClientResult<Option<User>>;
-    
+
     #[post(path = "/new_user")]
     async fn new_user(&self, #[json] user: &User) -> ClientResult<Option<String>>;
 
+    #[put(path = "/put_user/<id>")]
+    async fn put_user(&self, #[args] args: PutUserArgs) -> ClientResult<User>;
 }
 
 #[tokio::main]
@@ -60,4 +72,3 @@ async fn main() {
 - Reconfig host
 - Additional request processer
 - Custom deserializer
-

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ pub struct User {
 
 #[derive(Args)]
 pub struct PutUserArgs {
-    #[arg_path]
+    #[feigen_path]
     pub id: i64,
-    #[arg_query]
+    #[feigen_query]
     pub q: String,
-    #[arg_json]
+    #[feigen_json]
     pub data: User,
-    #[arg_headers]
+    #[feigen_headers]
     pub headers: HashMap<String, String>,
 }
 

--- a/feign-macros/src/lib.rs
+++ b/feign-macros/src/lib.rs
@@ -618,7 +618,7 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
     };
 
     let headers = match headers_field {
-        None => quote! {},
+        None => quote! {None},
         Some((field_name, _)) => quote! {
             Some(&self.#field_name)
         },

--- a/feign-macros/src/lib.rs
+++ b/feign-macros/src/lib.rs
@@ -565,15 +565,18 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
             quote! {
                 feign::RequestBody::Form(&self.#field_name)
             },
-            quote! {&#ty},
+            quote! {feign::RequestBody<&#ty>},
         ),
         (None, Some((field_name, ty))) => (
             quote! {
                 feign::RequestBody::Json(&self.#field_name)
             },
-            quote! {&#ty},
+            quote! {feign::RequestBody<&#ty>},
         ),
-        _ => (quote! {feign::RequestBody::<()>::None}, quote! {()}),
+        _ => (
+            quote! {feign::RequestBody::<()>::None},
+            quote! {feign::RequestBody<()>},
+        ),
     };
 
     let (headers, headers_type) = match headers_field {
@@ -596,7 +599,7 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
                 #query
             }
 
-            fn body(&self) -> feign::RequestBody<#body_type> {
+            fn body(&self) -> #body_type {
                 #body
             }
 

--- a/feign-macros/src/lib.rs
+++ b/feign-macros/src/lib.rs
@@ -499,7 +499,10 @@ struct Request {
 /// }
 /// ```
 #[proc_macro_error]
-#[proc_macro_derive(Args, attributes(arg_path, arg_query, arg_json, arg_form, arg_headers))]
+#[proc_macro_derive(
+    Args,
+    attributes(feigen_path, feigen_query, feigen_json, feigen_form, feigen_headers)
+)]
 pub fn derive_args(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     let name = &input.ident;
@@ -532,11 +535,11 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
             if let syn::Meta::Path(path) = &attr.meta {
                 if let Some(ident) = path.get_ident() {
                     match ident.to_string().as_str() {
-                        "arg_path" => has_path = true,
-                        "arg_query" => has_query = true,
-                        "arg_json" => has_json = true,
-                        "arg_form" => has_form = true,
-                        "arg_headers" => has_headers = true,
+                        "feigen_path" => has_path = true,
+                        "feigen_query" => has_query = true,
+                        "feigen_json" => has_json = true,
+                        "feigen_form" => has_form = true,
+                        "feigen_headers" => has_headers = true,
                         _ => {}
                     }
                 }

--- a/feign/README.md
+++ b/feign/README.md
@@ -9,8 +9,8 @@ Feign-RS (Rest client of Rust)
 ```rust
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
-
-use feign::{client, ClientResult};
+use std::collections::HashMap;
+use feign::{client, ClientResult, Args};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct User {
@@ -18,15 +18,29 @@ pub struct User {
     pub name: String,
 }
 
+#[derive(Args)]
+pub struct PutUserArgs {
+    #[arg_path]
+    pub id: i64,
+    #[arg_query]
+    pub q: String,
+    #[arg_json]
+    pub data: User,
+    #[arg_headers]
+    pub headers: HashMap<String, String>,
+}
+
 #[client(host = "http://127.0.0.1:3000", path = "/user")]
 pub trait UserClient {
-    
+
     #[get(path = "/find_by_id/<id>")]
     async fn find_by_id(&self, #[path] id: i64) -> ClientResult<Option<User>>;
-    
+
     #[post(path = "/new_user")]
     async fn new_user(&self, #[json] user: &User) -> ClientResult<Option<String>>;
 
+    #[put(path = "/put_user/<id>")]
+    async fn put_user(&self, #[args] args: PutUserArgs) -> ClientResult<User>;
 }
 
 #[tokio::main]

--- a/feign/README.md
+++ b/feign/README.md
@@ -20,13 +20,13 @@ pub struct User {
 
 #[derive(Args)]
 pub struct PutUserArgs {
-    #[arg_path]
+    #[feigen_path]
     pub id: i64,
-    #[arg_query]
+    #[feigen_query]
     pub q: String,
-    #[arg_json]
+    #[feigen_json]
     pub data: User,
-    #[arg_headers]
+    #[feigen_headers]
     pub headers: HashMap<String, String>,
 }
 

--- a/feign/src/lib.rs
+++ b/feign/src/lib.rs
@@ -18,11 +18,11 @@ pub enum HttpMethod {
     Head,
 }
 
-#[derive(Clone, Debug)]
-pub enum RequestBody {
+#[derive(Debug)]
+pub enum RequestBody<T> {
     None,
-    Json(serde_json::Value),
-    Form(serde_json::Value),
+    Json(T),
+    Form(T),
 }
 
 pub trait Host: Display + Debug + Sync + Send + 'static {

--- a/test/test-feign/Cargo.toml
+++ b/test/test-feign/Cargo.toml
@@ -2,6 +2,12 @@
 name = "test-feign"
 version = "0.1.0"
 edition = "2021"
+default-run = "main"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test/test-feign/Cargo.toml
+++ b/test/test-feign/Cargo.toml
@@ -8,7 +8,6 @@ default-run = "main"
 name = "main"
 path = "src/main.rs"
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/test/test-feign/src/main.rs
+++ b/test/test-feign/src/main.rs
@@ -36,13 +36,13 @@ pub struct User {
 
 #[derive(Args)]
 pub struct PutUserArgs {
-    #[arg_path]
+    #[feigen_path]
     pub id: i64,
-    #[arg_query]
+    #[feigen_query]
     pub q: String,
-    #[arg_json]
+    #[feigen_json]
     pub data: User,
-    #[arg_headers]
+    #[feigen_headers]
     pub headers: HashMap<String, String>,
 }
 

--- a/test/test-server/src/main.rs
+++ b/test/test-server/src/main.rs
@@ -24,7 +24,15 @@ async fn main() {
         .and(warp::body::json())
         .map(move |user: User| serde_json::to_string(&user.name).unwrap());
 
-    warp::serve(find_by_id.or(new_user))
+    let put_user = warp::put()
+        .and(warp::path!("user" / "put_user" / i64))
+        .and(warp::body::json())
+        .map(move |id: i64, mut user: User| {
+            user.id = id;
+            serde_json::to_string(&user).unwrap()
+        });
+
+    warp::serve(find_by_id.or(new_user).or(put_user))
         .run(([127, 0, 0, 1], 3030))
         .await;
 }


### PR DESCRIPTION
```rust
#[derive(feigen::Args)]
pub struct PutUserArgs {
    #[feigen_path]
    pub id: i64,
    #[feigen_query]
    pub q: String,
    #[feigen_json]
    pub data: User,
    #[feigen_headers]
    pub headers: HashMap<String, String>,
}

async fn before_send<T: Debug>(
    mut request_builder: reqwest::RequestBuilder,
    body: RequestBody<T>,
) -> ClientResult<reqwest::RequestBuilder> {
    let (client, request) = request_builder.build_split();
    match request {
        Ok(request) => {
            println!(
                "============= (Before_send)\n\
                    {:?} => {}{}\n\
                    {:?}\n\
                    {:?}",
                request.method(),
                request.url().host_str().unwrap_or_default(),
                request.url().path(),
                request.headers(),
                body
            );
            request_builder = reqwest::RequestBuilder::from_parts(client, request);
            Ok(request_builder.header("a", "b"))
        }
        Err(err) => Err(err.into()),
    }
}

#[feigen::client(before_send = "before_send",host = "http://127.0.0.1:3000", path = "/user")]
pub trait UserClient {
    #[get(path = "/find_by_id/<id>")]
    async fn find_by_id(&self, #[path] id: i64) -> ClientResult<Option<User>>;

    #[put(path = "/put_user/<id>")]
    async fn put_user(&self, #[args] args: PutUserArgs) -> ClientResult<User>;
}
```